### PR TITLE
Add simple homepage

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -42,7 +42,8 @@ INSTALLED_APPS = [
     'dictionary',
     'phrasebook',
     'grammar',
-    'drf_spectacular'
+    'drf_spectacular',
+    'website',
 ]
 
 MIDDLEWARE = [
@@ -60,7 +61,7 @@ ROOT_URLCONF = 'api.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -131,6 +132,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/api/urls.py
+++ b/api/urls.py
@@ -16,12 +16,15 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 from drf_spectacular.views import (
     SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 )
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('website.urls')),
     path('api/phrasebook/', include('phrasebook.urls')),
     path('api/dictionary/', include('dictionary.urls')),
     path('api/grammar/', include('grammar.urls')),
@@ -29,3 +32,6 @@ urlpatterns = [
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/website/admin.py
+++ b/website/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/website/apps.py
+++ b/website/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WebsiteConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "website"

--- a/website/models.py
+++ b/website/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/website/static/website/css/styles.css
+++ b/website/static/website/css/styles.css
@@ -1,0 +1,7 @@
+body {
+    padding-top: 60px;
+}
+
+.search-results {
+    margin-top: 20px;
+}

--- a/website/static/website/js/search.js
+++ b/website/static/website/js/search.js
@@ -1,0 +1,21 @@
+function searchWord() {
+    const query = document.getElementById('searchInput').value;
+    if (!query) return;
+    fetch(`/api/dictionary/search/?q=${encodeURIComponent(query)}`)
+        .then(res => res.json())
+        .then(data => {
+            const results = document.getElementById('results');
+            results.innerHTML = '';
+            if (data.length === 0) {
+                results.innerHTML = '<p>No results</p>';
+                return;
+            }
+            const list = document.createElement('ul');
+            data.forEach(item => {
+                const li = document.createElement('li');
+                li.textContent = item.text + ' - ' + item.language.code;
+                list.appendChild(li);
+            });
+            results.appendChild(list);
+        });
+}

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Avaro-English Dictionary</title>
+    {% load static %}
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{% static 'website/css/styles.css' %}" rel="stylesheet">
 </head>

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Avaro-English Dictionary</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'website/css/styles.css' %}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Avaro-English Dictionary</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="#">Dictionary</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">Phrasebook</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">Grammar</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">About</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">Avar names</a></li>
+                <li class="nav-item"><a class="nav-link" href="#">Geographical names</a></li>
+            </ul>
+            <div class="d-flex">
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageMenu" data-bs-toggle="dropdown" aria-expanded="false">
+                        Language
+                    </button>
+                    <ul class="dropdown-menu" aria-labelledby="languageMenu">
+                        <li><a class="dropdown-item" href="#">Avar - Latin</a></li>
+                        <li><a class="dropdown-item" href="#">Avar - Cyrillic</a></li>
+                        <li><a class="dropdown-item" href="#">English</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<div class="container">
+    <div class="row">
+        <div class="col-12">
+            <h1 class="mt-3">Avaro-English Dictionary</h1>
+            <div class="input-group mt-3">
+                <input type="text" id="searchInput" class="form-control" placeholder="Search words...">
+                <button class="btn btn-primary" onclick="searchWord()">Search</button>
+            </div>
+            <div id="results" class="search-results"></div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{% static 'website/js/search.js' %}"></script>
+</body>
+</html>

--- a/website/tests.py
+++ b/website/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.index, name='index'),
+]

--- a/website/views.py
+++ b/website/views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def index(request):
+    return render(request, 'website/index.html')


### PR DESCRIPTION
## Summary
- add `website` app for HTML views
- create responsive index page with search
- serve static files in development
- register the app in Django settings

## Testing
- `pip install -r requirements.txt`
- `python manage.py makemigrations`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68716deeb64c832db0934670fc230720