### PR TITLE
Fix site URLs and add placeholder pages

### DIFF
--- a/website/templates/website/about.html
+++ b/website/templates/website/about.html
@@ -1,0 +1,6 @@
+{% extends "website/base.html" %}
+{% block title %}About – Avaro-English{% endblock %}
+{% block content %}
+<h1>About</h1>
+<p>Информация о проекте появится здесь позже.</p>
+{% endblock %}

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Avaro-English{% endblock %}</title>
-  <link rel="stylesheet" href="{% static 'css/style.css' %}">
+  <link rel="stylesheet" href="{% static 'website/css/styles.css' %}">
 </head>
 <body>
   <header class="site-header">

--- a/website/templates/website/contact.html
+++ b/website/templates/website/contact.html
@@ -1,0 +1,6 @@
+{% extends "website/base.html" %}
+{% block title %}Contact – Avaro-English{% endblock %}
+{% block content %}
+<h1>Contact</h1>
+<p>Свяжитесь с нами: example@example.com</p>
+{% endblock %}

--- a/website/templates/website/dictionary.html
+++ b/website/templates/website/dictionary.html
@@ -1,0 +1,6 @@
+{% extends "website/base.html" %}
+{% block title %}Dictionary – Avaro-English{% endblock %}
+{% block content %}
+<h1>Dictionary</h1>
+<p>Эта страница словаря будет реализована позже.</p>
+{% endblock %}

--- a/website/templates/website/grammar.html
+++ b/website/templates/website/grammar.html
@@ -1,0 +1,6 @@
+{% extends "website/base.html" %}
+{% block title %}Grammar – Avaro-English{% endblock %}
+{% block content %}
+<h1>Grammar</h1>
+<p>Эта страница грамматики будет реализована позже.</p>
+{% endblock %}

--- a/website/templates/website/names.html
+++ b/website/templates/website/names.html
@@ -1,0 +1,6 @@
+{% extends "website/base.html" %}
+{% block title %}Names – Avaro-English{% endblock %}
+{% block content %}
+<h1>Names</h1>
+<p>Эта страница имён будет реализована позже.</p>
+{% endblock %}

--- a/website/templates/website/phrasebook.html
+++ b/website/templates/website/phrasebook.html
@@ -1,0 +1,6 @@
+{% extends "website/base.html" %}
+{% block title %}Phrasebook – Avaro-English{% endblock %}
+{% block content %}
+<h1>Phrasebook</h1>
+<p>Эта страница разговорника будет реализована позже.</p>
+{% endblock %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,6 +1,13 @@
 from django.urls import path
 from . import views
 
+
 urlpatterns = [
-    path('', views.index, name='index'),
+    path('', views.index, name='home'),
+    path('dictionary/', views.dictionary, name='dictionary'),
+    path('phrasebook/', views.phrasebook, name='phrasebook'),
+    path('grammar/', views.grammar, name='grammar'),
+    path('names/', views.names, name='names'),
+    path('about/', views.about, name='about'),
+    path('contact/', views.contact, name='contact'),
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -3,3 +3,27 @@ from django.shortcuts import render
 
 def index(request):
     return render(request, 'website/index.html')
+
+
+def dictionary(request):
+    return render(request, 'website/dictionary.html')
+
+
+def phrasebook(request):
+    return render(request, 'website/phrasebook.html')
+
+
+def grammar(request):
+    return render(request, 'website/grammar.html')
+
+
+def names(request):
+    return render(request, 'website/names.html')
+
+
+def about(request):
+    return render(request, 'website/about.html')
+
+
+def contact(request):
+    return render(request, 'website/contact.html')


### PR DESCRIPTION
## Summary
- connect style.css properly in base template
- add placeholders for about/contact/dictionary/grammar/names/phrasebook pages
- define views for each new page
- update URL config to register new routes

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6871756bd5cc832d83cb8b90bd130bb9