### PR TITLE
Implement dictionary UI and design tweaks

### DIFF
--- a/website/static/website/css/styles.css
+++ b/website/static/website/css/styles.css
@@ -10,7 +10,7 @@
   padding: 0;
 }
 body {
-  font-family: system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif;
+  font-family: 'Inter', system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif;
   background: #FAFAFA;
   color: #111827;
   line-height: 1.5;
@@ -82,6 +82,11 @@ body {
   text-align: center;
 }
 
+.page-title {
+  font-size: 1.75rem;
+  margin: 16px 0;
+}
+
 /* Карточки */
 .card-grid {
   display: grid;
@@ -124,6 +129,24 @@ body {
   border-radius: 0 4px 4px 0;
   color: #fff;
   font-weight: 600;
+}
+
+/* Dictionary page */
+.results-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 16px;
+}
+.results-list li {
+  padding: 8px 12px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+.results-list li:hover {
+  background: #f5f5f5;
+}
+.word-details {
+  margin-top: 24px;
 }
 
 /* Карточка About под поиском */

--- a/website/static/website/js/dictionary.js
+++ b/website/static/website/js/dictionary.js
@@ -1,0 +1,56 @@
+// Handle dictionary page interactions
+function fetchWordDetails(id) {
+    fetch(`/api/dictionary/words/${id}/`)
+        .then(res => res.json())
+        .then(data => {
+            const container = document.getElementById('wordDetails');
+            container.innerHTML = '';
+            const title = document.createElement('h2');
+            title.textContent = data.text;
+            container.appendChild(title);
+            if (data.transcription) {
+                const tr = document.createElement('p');
+                tr.textContent = data.transcription;
+                container.appendChild(tr);
+            }
+            if (data.translations && data.translations.length) {
+                const tTitle = document.createElement('h3');
+                tTitle.textContent = 'Translations';
+                container.appendChild(tTitle);
+                const ul = document.createElement('ul');
+                data.translations.forEach(t => {
+                    const li = document.createElement('li');
+                    li.textContent = `${t.to_word.text} - ${t.to_word.language.code}`;
+                    ul.appendChild(li);
+                });
+                container.appendChild(ul);
+            }
+            if (data.examples && data.examples.length) {
+                const eTitle = document.createElement('h3');
+                eTitle.textContent = 'Examples';
+                container.appendChild(eTitle);
+                const ul = document.createElement('ul');
+                data.examples.forEach(ex => {
+                    const li = document.createElement('li');
+                    li.textContent = ex.translation ? `${ex.text} - ${ex.translation}` : ex.text;
+                    ul.appendChild(li);
+                });
+                container.appendChild(ul);
+            }
+        });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('searchForm');
+    if (form) {
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            searchWord();
+        });
+    }
+    document.getElementById('results').addEventListener('click', (e) => {
+        if (e.target.tagName === 'LI') {
+            fetchWordDetails(e.target.dataset.id);
+        }
+    });
+});

--- a/website/static/website/js/search.js
+++ b/website/static/website/js/search.js
@@ -1,5 +1,5 @@
 function searchWord() {
-    const query = document.getElementById('searchInput').value;
+    const query = document.getElementById('searchInput').value.trim();
     if (!query) return;
     fetch(`/api/dictionary/search/?q=${encodeURIComponent(query)}`)
         .then(res => res.json())
@@ -11,9 +11,11 @@ function searchWord() {
                 return;
             }
             const list = document.createElement('ul');
+            list.className = 'results-list';
             data.forEach(item => {
                 const li = document.createElement('li');
                 li.textContent = item.text + ' - ' + item.language.code;
+                li.dataset.id = item.id;
                 list.appendChild(li);
             });
             results.appendChild(list);

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Avaro-English{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{% static 'website/css/styles.css' %}">
 </head>
 <body>
@@ -31,5 +33,6 @@
     <a href="{% url 'contact' %}">Связаться с нами</a>
   </footer>
   <script src="{% static 'website/js/base.js' %}"></script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/website/templates/website/dictionary.html
+++ b/website/templates/website/dictionary.html
@@ -1,4 +1,5 @@
 {% extends "website/base.html" %}
+{% load static %}
 {% block title %}Dictionary – Avaro-English{% endblock %}
 {% block content %}
 <section class="dictionary-page">

--- a/website/templates/website/dictionary.html
+++ b/website/templates/website/dictionary.html
@@ -1,6 +1,17 @@
 {% extends "website/base.html" %}
 {% block title %}Dictionary – Avaro-English{% endblock %}
 {% block content %}
-<h1>Dictionary</h1>
-<p>Эта страница словаря будет реализована позже.</p>
+<section class="dictionary-page">
+  <h1 class="page-title">Dictionary</h1>
+  <form id="searchForm" class="search-section" onsubmit="return false;">
+    <input type="search" id="searchInput" class="search-input" placeholder="Search..." required>
+    <button type="submit" class="search-btn">Search</button>
+  </form>
+  <div id="results"></div>
+  <div id="wordDetails" class="word-details"></div>
+</section>
+{% endblock %}
+{% block scripts %}
+<script src="{% static 'website/js/search.js' %}"></script>
+<script src="{% static 'website/js/dictionary.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Google Fonts and script block to base template
- implement dynamic dictionary page with search and word details
- enhance search script with result IDs and styling
- add dedicated dictionary JavaScript
- update styles including font, page title, and dictionary layout

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68717ab340f8832db113637ccbbd6b66