### PR TITLE
Add live dictionary suggestions

### DIFF
--- a/website/static/website/js/dictionary.js
+++ b/website/static/website/js/dictionary.js
@@ -42,11 +42,19 @@ function fetchWordDetails(id) {
 
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('searchForm');
+    const input = document.getElementById('searchInput');
     if (form) {
         form.addEventListener('submit', (e) => {
             e.preventDefault();
             searchWord();
         });
+    }
+    if (input) {
+        input.addEventListener('input', () => {
+            fetchWords(input.value.trim());
+        });
+        // initial list when page loads
+        fetchWords('');
     }
     document.getElementById('results').addEventListener('click', (e) => {
         if (e.target.tagName === 'LI') {

--- a/website/static/website/js/search.js
+++ b/website/static/website/js/search.js
@@ -1,23 +1,29 @@
-function searchWord() {
-    const query = document.getElementById('searchInput').value.trim();
-    if (!query) return;
+function updateResults(data) {
+    const results = document.getElementById('results');
+    results.innerHTML = '';
+    if (!data || data.length === 0) {
+        results.innerHTML = '<p>No results</p>';
+        return;
+    }
+    const list = document.createElement('ul');
+    list.className = 'results-list';
+    data.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = item.text + ' - ' + item.language.code;
+        li.dataset.id = item.id;
+        list.appendChild(li);
+    });
+    results.appendChild(list);
+}
+
+function fetchWords(query = '') {
     fetch(`/api/dictionary/search/?q=${encodeURIComponent(query)}`)
         .then(res => res.json())
-        .then(data => {
-            const results = document.getElementById('results');
-            results.innerHTML = '';
-            if (data.length === 0) {
-                results.innerHTML = '<p>No results</p>';
-                return;
-            }
-            const list = document.createElement('ul');
-            list.className = 'results-list';
-            data.forEach(item => {
-                const li = document.createElement('li');
-                li.textContent = item.text + ' - ' + item.language.code;
-                li.dataset.id = item.id;
-                list.appendChild(li);
-            });
-            results.appendChild(list);
-        });
+        .then(updateResults);
+}
+
+// Legacy API used by some handlers
+function searchWord() {
+    const query = document.getElementById('searchInput').value.trim();
+    fetchWords(query);
 }

--- a/website/templates/website/dictionary.html
+++ b/website/templates/website/dictionary.html
@@ -5,7 +5,7 @@
 <section class="dictionary-page">
   <h1 class="page-title">Dictionary</h1>
   <form id="searchForm" class="search-section" onsubmit="return false;">
-    <input type="search" id="searchInput" class="search-input" placeholder="Search..." required>
+    <input type="search" id="searchInput" class="search-input" placeholder="Search...">
     <button type="submit" class="search-btn">Search</button>
   </form>
   <div id="results"></div>


### PR DESCRIPTION
## Summary
- update JS to fetch results as user types
- show initial word list on dictionary page
- allow empty search query by removing `required` attribute on input

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68717da411cc832d939b4ec3f89dea44