### PR TITLE
Improve UI navigation and dictionary search

### DIFF
--- a/website/static/website/css/styles.css
+++ b/website/static/website/css/styles.css
@@ -32,6 +32,7 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
+  position: relative;
 }
 .logo {
   font-size: 1.25rem;
@@ -45,6 +46,25 @@ body {
   color: #fff;
   font-size: 1.25rem;
   cursor: pointer;
+}
+.site-nav {
+  display: none;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--primary);
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  padding: 8px 16px;
+}
+.site-nav a {
+  color: #fff;
+  text-decoration: none;
+  padding: 4px 0;
+}
+.site-nav.open {
+  display: flex;
 }
 .lang-switcher {
   position: relative;
@@ -130,6 +150,10 @@ body {
   color: #fff;
   font-weight: 600;
 }
+.direction-btn {
+  border-radius: 0;
+  margin: 0 4px;
+}
 
 /* Dictionary page */
 .results-list {
@@ -174,6 +198,15 @@ body {
 @media (min-width: 600px) {
   .card-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+  .site-nav {
+    display: flex !important;
+    position: static;
+    flex-direction: row;
+    gap: 16px;
+  }
+  .btn-menu {
+    display: none;
   }
 }
 

--- a/website/static/website/js/base.js
+++ b/website/static/website/js/base.js
@@ -12,4 +12,18 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
+
+  const menuBtn = document.querySelector('.btn-menu');
+  const nav = document.querySelector('.site-nav');
+  if (menuBtn && nav) {
+    menuBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      nav.classList.toggle('open');
+    });
+    document.addEventListener('click', function(e) {
+      if (!nav.contains(e.target) && e.target !== menuBtn) {
+        nav.classList.remove('open');
+      }
+    });
+  }
 });

--- a/website/static/website/js/dictionary.js
+++ b/website/static/website/js/dictionary.js
@@ -43,18 +43,48 @@ function fetchWordDetails(id) {
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('searchForm');
     const input = document.getElementById('searchInput');
+    const toggle = document.getElementById('directionToggle');
+    let fromLang = 'av';
+    let toLang = 'en';
+    if (toggle) {
+        toggle.textContent = `${fromLang}→${toLang}`;
+        toggle.addEventListener('click', () => {
+            [fromLang, toLang] = [toLang, fromLang];
+            toggle.textContent = `${fromLang}→${toLang}`;
+        });
+    }
+
+    async function quickTranslate(word) {
+        if (!word) {
+            document.getElementById('results').innerHTML = '';
+            document.getElementById('wordDetails').innerHTML = '';
+            return;
+        }
+        const url = `/api/dictionary/translate/?word=${encodeURIComponent(word)}&from=${fromLang}&to=${toLang}`;
+        const res = await fetch(url);
+        const data = await res.json();
+        const results = document.getElementById('results');
+        results.innerHTML = '';
+        if (!data.length) {
+            results.textContent = 'No translations';
+            return;
+        }
+        const list = document.createElement('ul');
+        list.className = 'results-list';
+        data.forEach(t => {
+            const li = document.createElement('li');
+            li.textContent = t.to_word.text + ' - ' + t.to_word.language.code;
+            li.dataset.id = t.to_word.id;
+            list.appendChild(li);
+        });
+        results.appendChild(list);
+    }
+
     if (form) {
         form.addEventListener('submit', (e) => {
             e.preventDefault();
-            searchWord();
+            quickTranslate(input.value.trim());
         });
-    }
-    if (input) {
-        input.addEventListener('input', () => {
-            fetchWords(input.value.trim());
-        });
-        // initial list when page loads
-        fetchWords('');
     }
     document.getElementById('results').addEventListener('click', (e) => {
         if (e.target.tagName === 'LI') {

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -13,6 +13,13 @@
     <div class="container header-inner">
       <button class="btn-menu" aria-label="Toggle menu">☰</button>
       <a href="{% url 'home' %}" class="logo">Avaro-English</a>
+      <nav class="site-nav">
+        <a href="{% url 'dictionary' %}">Dictionary</a>
+        <a href="{% url 'phrasebook' %}">Phrasebook</a>
+        <a href="{% url 'grammar' %}">Grammar</a>
+        <a href="{% url 'names' %}">Names</a>
+        <a href="{% url 'about' %}">About</a>
+      </nav>
       <div class="lang-switcher">
         <button class="btn-lang" type="button">Language ▾</button>
         <ul class="lang-list">

--- a/website/templates/website/dictionary.html
+++ b/website/templates/website/dictionary.html
@@ -6,6 +6,7 @@
   <h1 class="page-title">Dictionary</h1>
   <form id="searchForm" class="search-section" onsubmit="return false;">
     <input type="search" id="searchInput" class="search-input" placeholder="Search...">
+    <button id="directionToggle" type="button" class="search-btn direction-btn">av→en</button>
     <button type="submit" class="search-btn">Search</button>
   </form>
   <div id="results"></div>
@@ -13,6 +14,5 @@
 </section>
 {% endblock %}
 {% block scripts %}
-<script src="{% static 'website/js/search.js' %}"></script>
 <script src="{% static 'website/js/dictionary.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add navigation items to header and enable toggle
- implement quick translation with language direction switch
- style menu, direction button and responsive header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a5b5c65c832d949dc3d594deef26