### PR TITLE
Fix mobile menu toggle

### DIFF
--- a/website/static/website/js/base.js
+++ b/website/static/website/js/base.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function() {
+function initMenu() {
   const switcher = document.querySelector('.lang-switcher');
   if (switcher) {
     const btn = switcher.querySelector('.btn-lang');
@@ -26,4 +26,10 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMenu);
+} else {
+  initMenu();
+}


### PR DESCRIPTION
## Summary
- fix header menu toggle by running initializer even if DOMContentLoaded already fired

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6873bddfeb08832d9e0bc8ec400c4fd7