### PR TITLE
Improve query param filtering

### DIFF
--- a/api/mixins.py
+++ b/api/mixins.py
@@ -1,14 +1,23 @@
-from typing import Mapping
+from typing import Callable, Mapping, Union
 from django.db.models import QuerySet
+
+
+FilterFunc = Callable[[QuerySet, str], QuerySet]
+
 
 class QueryParamsFilterMixin:
     """Filter a queryset based on request query parameters."""
-    query_params_map: Mapping[str, str] = {}
+
+    query_params_map: Mapping[str, Union[str, FilterFunc]] = {}
 
     def filter_queryset_by_params(self, queryset: QuerySet) -> QuerySet:
         for param, lookup in self.query_params_map.items():
             value = self.request.query_params.get(param)
-            if value:
+            if not value:
+                continue
+            if callable(lookup):
+                queryset = lookup(queryset, value)
+            else:
                 queryset = queryset.filter(**{lookup: value})
         return queryset
 

--- a/dictionary/tests.py
+++ b/dictionary/tests.py
@@ -1,3 +1,22 @@
+from django.urls import reverse
 from django.test import TestCase
+from rest_framework.test import APIClient
 
-# Create your tests here.
+from .models import Language, Word, Synonym
+
+
+class SynonymFilterTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.lang = Language.objects.create(code="av", name="Avar")
+        self.word1 = Word.objects.create(text="a", language=self.lang)
+        self.word2 = Word.objects.create(text="b", language=self.lang)
+        self.word3 = Word.objects.create(text="c", language=self.lang)
+        Synonym.objects.create(word1=self.word1, word2=self.word2)
+        Synonym.objects.create(word1=self.word2, word2=self.word3)
+
+    def test_filter_by_word_id(self):
+        url = reverse("synonym-list") + f"?word_id={self.word2.id}"
+        response = self.client.get(url)
+        self.assertEqual(len(response.data), 2)
+

--- a/dictionary/views.py
+++ b/dictionary/views.py
@@ -45,16 +45,13 @@ class ExampleViewSet(QueryParamsFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = ExampleSerializer
     query_params_map = {"word_id": "word_id"}
 
-class SynonymViewSet(viewsets.ReadOnlyModelViewSet):
+class SynonymViewSet(QueryParamsFilterMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Synonym.objects.select_related('word1', 'word2').all()
     serializer_class = SynonymSerializer
 
-    def get_queryset(self):
-        qs = super().get_queryset()
-        word_id = self.request.query_params.get('word_id')
-        if word_id:
-            qs = qs.filter(Q(word1_id=word_id) | Q(word2_id=word_id))
-        return qs
+    query_params_map = {
+        "word_id": lambda qs, value: qs.filter(Q(word1_id=value) | Q(word2_id=value)),
+    }
 
 # Поиск по слову с фильтрами
 @api_view(['GET'])


### PR DESCRIPTION
## Summary
- extend `QueryParamsFilterMixin` to support callable filters
- simplify synonym filtering logic
- add tests covering new behavior

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6873bf600d70832da580e084a40b6439