### PR TITLE
Add editable about page

### DIFF
--- a/website/admin.py
+++ b/website/admin.py
@@ -1,8 +1,13 @@
 from django.contrib import admin
-from .models import Visit
+from .models import Visit, ProjectInfo
 
 
 @admin.register(Visit)
 class VisitAdmin(admin.ModelAdmin):
     list_display = ("session_key", "ip_address", "date", "last_activity")
     search_fields = ("session_key", "ip_address")
+
+
+@admin.register(ProjectInfo)
+class ProjectInfoAdmin(admin.ModelAdmin):
+    list_display = ("title", "updated_at")

--- a/website/models.py
+++ b/website/models.py
@@ -19,3 +19,18 @@ class Visit(models.Model):
     def __str__(self) -> str:
         return f"{self.session_key} @ {self.date}"
 
+
+class ProjectInfo(models.Model):
+    """Content for the About page editable via the admin."""
+
+    title = models.CharField("Заголовок", max_length=256, default="О проекте")
+    content = models.TextField("Описание")
+    updated_at = models.DateTimeField("Изменено", auto_now=True)
+
+    class Meta:
+        verbose_name = "Информация о проекте"
+        verbose_name_plural = "Информация о проекте"
+
+    def __str__(self) -> str:
+        return self.title
+

--- a/website/templates/website/about.html
+++ b/website/templates/website/about.html
@@ -1,6 +1,10 @@
 {% extends "website/base.html" %}
 {% block title %}About – Avaro-English{% endblock %}
 {% block content %}
-<h1>About</h1>
-<p>Информация о проекте появится здесь позже.</p>
+<h1>{{ project_info.title|default:'About' }}</h1>
+{% if project_info %}
+  <div class="project-content">{{ project_info.content|safe }}</div>
+{% else %}
+  <p>Информация о проекте появится здесь позже.</p>
+{% endif %}
 {% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
+from .models import ProjectInfo
 
 
 class StaticPagesTests(TestCase):
@@ -23,3 +24,10 @@ class StaticPagesTests(TestCase):
         response = self.client.get(reverse('home'))
         self.assertIn('active_visitors', response.context)
         self.assertIn('unique_visitors_today', response.context)
+
+
+class AboutPageTests(TestCase):
+    def test_about_page_shows_project_info(self):
+        info = ProjectInfo.objects.create(content='Test project info')
+        response = self.client.get(reverse('about'))
+        self.assertContains(response, 'Test project info')

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from django.views.generic import TemplateView
+from .views import AboutView
 
 
 urlpatterns = [
@@ -8,6 +9,6 @@ urlpatterns = [
     path('phrasebook/', TemplateView.as_view(template_name='website/phrasebook.html'), name='phrasebook'),
     path('grammar/', TemplateView.as_view(template_name='website/grammar.html'), name='grammar'),
     path('names/', TemplateView.as_view(template_name='website/names.html'), name='names'),
-    path('about/', TemplateView.as_view(template_name='website/about.html'), name='about'),
+    path('about/', AboutView.as_view(), name='about'),
     path('contact/', TemplateView.as_view(template_name='website/contact.html'), name='contact'),
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -1,0 +1,11 @@
+from django.views.generic import TemplateView
+from .models import ProjectInfo
+
+
+class AboutView(TemplateView):
+    template_name = 'website/about.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project_info'] = ProjectInfo.objects.order_by('-updated_at').first()
+        return context


### PR DESCRIPTION
## Summary
- create `ProjectInfo` model to store site description
- register it in the admin
- show project info on `/about/`
- add unit test verifying the text appears

## Testing
- `./manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6873c0ed01a0832d86a9c6ecf6adc6fa