### PR TITLE
Display both languages in quick translate results

### DIFF
--- a/website/static/website/js/dictionary.js
+++ b/website/static/website/js/dictionary.js
@@ -77,7 +77,9 @@ document.addEventListener('DOMContentLoaded', () => {
         list.className = 'results-list';
         data.forEach(t => {
             const li = document.createElement('li');
-            li.textContent = t.to_word.text + ' - ' + t.to_word.language.code;
+            const fromText = `${t.from_word.text} (${t.from_word.language.code})`;
+            const toText = `${t.to_word.text} (${t.to_word.language.code})`;
+            li.textContent = `${fromText} → ${toText}`;
             li.dataset.id = t.to_word.id;
             list.appendChild(li);
         });


### PR DESCRIPTION
## Summary
- show both the source and target words, along with their language codes, in the quick translate result list so users can see the full translation pair

## Testing
- python manage.py test *(fails: OperationalError: no such table: website_projectinfo / Missing staticfiles manifest entry for 'website/css/styles.css')*

------
https://chatgpt.com/codex/tasks/task_e_68e2bc1c4808832dbf7349baed97d538