### PR TITLE
Add names migrations package marker and admin changelist smoke tests

### DIFF
--- a/names/migrations/__init__.py
+++ b/names/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Database migrations for the names app."""

--- a/names/tests_admin.py
+++ b/names/tests_admin.py
@@ -1,0 +1,22 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+
+class NamesAdminTests(TestCase):
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.admin_user = user_model.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="password123",
+        )
+        self.client.force_login(self.admin_user)
+
+    def test_name_category_admin_changelist_loads(self):
+        response = self.client.get(reverse("admin:names_namecategory_changelist"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_avar_name_admin_changelist_loads(self):
+        response = self.client.get(reverse("admin:names_avarname_changelist"))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Motivation

- Navigating Avar names and name categories in the admin was causing errors because the `names` app had no migrations package marker, which prevented model tables from being available in some environments.  
- Add tests to guard against regressions where admin changelists fail to load.  

### Description

- Add `names/migrations/__init__.py` to mark the migrations package so Django recognizes and applies migrations for the `names` app.  
- Add `names/tests_admin.py` containing admin smoke tests that create a superuser and assert the changelist pages for `NameCategory` and `AvarName` load.  

### Testing

- Ran `python manage.py test` after changes, which executed the full test suite.  
- Test run completed successfully with all tests passing (`24 tests, OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e96ffa38c832db54ac31aa1a00121)