### PR TITLE
Redesign homepage to Avar-inspired UI and assets

### DIFF
--- a/website/static/website/css/styles.css
+++ b/website/static/website/css/styles.css
@@ -1,13 +1,16 @@
 :root {
-  --primary: #1f3d3b;
-  --primary-dark: #122928;
-  --accent: #c7773c;
-  --accent-soft: #f2d6bf;
-  --surface: #fffdf8;
-  --surface-muted: #f6f0e8;
-  --text-color: #1f2422;
-  --text-muted: #5c625f;
-  --shadow: 0 25px 45px rgba(17, 32, 30, 0.15);
+  --primary: #2d0b1b;
+  --primary-dark: #16060e;
+  --accent: #f3722c;
+  --accent-strong: #ff9e43;
+  --accent-soft: #f6c18b;
+  --surface: #1a0a14;
+  --surface-alt: #27101f;
+  --surface-card: #3a1226;
+  --text-color: #f9e9df;
+  --text-muted: #d8b5b0;
+  --shadow: 0 30px 60px rgba(8, 2, 8, 0.6);
+  --glow: 0 0 40px rgba(243, 114, 44, 0.35);
   --pattern: url("../images/avar-pattern.svg");
 }
 
@@ -23,10 +26,11 @@ body {
   margin: 0;
   font-family: 'Manrope', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   background:
-    radial-gradient(circle at top left, rgba(199, 119, 60, 0.2), transparent 48%),
-    radial-gradient(circle at bottom right, rgba(31, 61, 59, 0.2), transparent 52%),
+    radial-gradient(circle at 18% 20%, rgba(243, 114, 44, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 12%, rgba(144, 24, 60, 0.45), transparent 45%),
+    radial-gradient(circle at 50% 85%, rgba(30, 7, 18, 0.9), transparent 55%),
     var(--pattern),
-    var(--surface-muted);
+    #12050d;
   color: var(--text-color);
   line-height: 1.6;
   min-height: 100vh;
@@ -40,7 +44,7 @@ a {
 
 a:hover,
 a:focus {
-  color: var(--primary);
+  color: var(--accent-soft);
 }
 
 img {
@@ -62,8 +66,9 @@ img {
 .site-header {
   position: relative;
   overflow: hidden;
-  background: linear-gradient(120deg, #122928 15%, #254846 60%, #1f3d3b 100%);
-  color: #f9fafb;
+  background: linear-gradient(120deg, #240a16 15%, #381126 60%, #2a0d1f 100%);
+  color: #fdf3ea;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
 }
 
 .header-ornament {
@@ -72,8 +77,8 @@ img {
   width: 360px;
   height: 360px;
   background:
-    radial-gradient(circle at 30% 30%, rgba(199, 119, 60, 0.65), transparent 65%),
-    radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.2), transparent 70%);
+    radial-gradient(circle at 30% 30%, rgba(240, 124, 43, 0.65), transparent 65%),
+    radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.15), transparent 70%);
   opacity: 0.85;
   filter: blur(0.5px);
   transform: rotate(18deg);
@@ -98,10 +103,10 @@ img {
 }
 
 .logo {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  color: #f9fafb;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  color: #fdf3ea;
 }
 
 .logo-kicker {
@@ -118,6 +123,19 @@ img {
   letter-spacing: 0.04em;
 }
 
+.logo-mark {
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.35));
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .btn-menu {
   display: flex;
   align-items: center;
@@ -125,8 +143,8 @@ img {
   width: 44px;
   height: 44px;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.08);
   color: #fff;
   font-size: 1.4rem;
   cursor: pointer;
@@ -135,7 +153,7 @@ img {
 
 .btn-menu:hover,
 .btn-menu:focus {
-  background: rgba(199, 119, 60, 0.25);
+  background: rgba(240, 124, 43, 0.3);
   transform: translateY(-1px);
 }
 
@@ -150,7 +168,7 @@ img {
 .site-nav a {
   position: relative;
   padding: 0.25rem 0;
-  color: rgba(255, 255, 255, 0.88);
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .site-nav a::after {
@@ -160,7 +178,7 @@ img {
   bottom: -6px;
   width: 100%;
   height: 2px;
-  background: rgba(199, 119, 60, 0.65);
+  background: rgba(240, 124, 43, 0.7);
   transform: scaleX(0);
   transform-origin: left;
   transition: transform 0.25s ease;
@@ -172,18 +190,20 @@ img {
 }
 
 .nav-cta {
-  padding: 0.45rem 1.15rem;
+  padding: 0.45rem 1.25rem;
   border-radius: 999px;
-  background: rgba(199, 119, 60, 0.28);
-  border: 1px solid rgba(199, 119, 60, 0.6);
-  color: #fff;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  background: linear-gradient(135deg, rgba(243, 114, 44, 0.95), rgba(255, 158, 67, 0.8));
+  border: 1px solid rgba(243, 114, 44, 0.85);
+  color: #3c1205;
+  box-shadow: 0 10px 20px rgba(243, 114, 44, 0.3);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .nav-cta:hover,
 .nav-cta:focus {
-  background: rgba(199, 119, 60, 0.45);
-  border-color: rgba(199, 119, 60, 0.85);
+  background: linear-gradient(135deg, rgba(255, 158, 67, 0.98), rgba(243, 114, 44, 0.9));
+  border-color: rgba(255, 158, 67, 0.98);
+  transform: translateY(-1px);
 }
 
 .lang-switcher {
@@ -197,8 +217,8 @@ img {
   gap: 0.35rem;
   padding: 0.5rem 0.85rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.14);
-  border: 1px solid rgba(255, 255, 255, 0.32);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.26);
   color: #fff;
   font-weight: 600;
   cursor: pointer;
@@ -208,8 +228,8 @@ img {
 .btn-lang:hover,
 .btn-lang:focus,
 .lang-switcher.active .btn-lang {
-  background: rgba(199, 119, 60, 0.28);
-  border-color: rgba(199, 119, 60, 0.65);
+  background: rgba(240, 124, 43, 0.25);
+  border-color: rgba(240, 124, 43, 0.6);
 }
 
 .lang-icon {
@@ -226,7 +246,7 @@ img {
   margin: 0;
   padding: 0.75rem 0.9rem;
   border-radius: 14px;
-  background: rgba(3, 15, 23, 0.94);
+  background: rgba(18, 6, 16, 0.94);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 14px 35px rgba(0, 0, 0, 0.25);
   display: none;
@@ -247,8 +267,19 @@ img {
 
 .lang-list a:hover,
 .lang-list a:focus {
-  background: rgba(199, 119, 60, 0.18);
+  background: rgba(240, 124, 43, 0.18);
   color: #fff;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .site-main {
@@ -259,13 +290,15 @@ img {
 .hero {
   position: relative;
   overflow: hidden;
-  border-radius: clamp(1.8rem, 4vw, 2.75rem);
+  border-radius: clamp(2rem, 4vw, 2.75rem);
   background:
-    linear-gradient(135deg, rgba(18, 41, 40, 0.92), rgba(18, 41, 40, 0.7)),
-    url("https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80") center/cover;
-  color: #f9fafb;
+    radial-gradient(circle at 18% 20%, rgba(243, 114, 44, 0.35), transparent 45%),
+    radial-gradient(circle at 80% 80%, rgba(130, 16, 50, 0.65), transparent 55%),
+    linear-gradient(135deg, rgba(32, 7, 17, 0.98), rgba(62, 15, 33, 0.95));
+  color: #fdf3ea;
   padding: clamp(2.75rem, 6vw, 4.6rem);
   box-shadow: var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .hero::after {
@@ -273,10 +306,10 @@ img {
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 20% 20%, rgba(199, 119, 60, 0.45), transparent 55%),
-    radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.15), transparent 60%),
+    radial-gradient(circle at 20% 20%, rgba(243, 114, 44, 0.45), transparent 55%),
+    radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.12), transparent 60%),
     var(--pattern);
-  mix-blend-mode: screen;
+  mix-blend-mode: lighten;
   opacity: 0.75;
 }
 
@@ -284,8 +317,25 @@ img {
   position: relative;
   z-index: 1;
   display: grid;
-  gap: clamp(1.8rem, 3vw, 2.5rem);
-  max-width: 680px;
+  gap: clamp(2rem, 4vw, 3rem);
+  grid-template-columns: minmax(240px, 1fr) minmax(280px, 1.1fr);
+  align-items: center;
+}
+
+.hero-media {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hero-media img {
+  width: min(360px, 80%);
+  filter: drop-shadow(0 22px 35px rgba(0, 0, 0, 0.45));
+}
+
+.hero-content {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2rem);
 }
 
 .hero-kicker {
@@ -314,6 +364,13 @@ img {
   margin: 0;
 }
 
+.hero-title span {
+  display: block;
+  font-family: 'Rubik', 'Manrope', sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  color: var(--accent-soft);
+}
+
 .hero-lede {
   margin: 0;
   font-size: clamp(1rem, 1.9vw, 1.2rem);
@@ -329,23 +386,53 @@ img {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.75rem;
-  background: rgba(3, 15, 23, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  backdrop-filter: blur(8px);
+  gap: 0.85rem;
+}
+
+.search-field {
+  flex: 1 1 260px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(18, 6, 16, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 18px;
-  padding: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  backdrop-filter: blur(10px);
+}
+
+.search-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: rgba(243, 114, 44, 0.2);
+  font-size: 0.95rem;
 }
 
 .hero-search input[type="search"] {
-  flex: 1 1 220px;
+  flex: 1 1 200px;
   min-width: 0;
-  padding: 0.85rem 1.1rem;
-  border-radius: 14px;
+  padding: 0.6rem 0.4rem;
+  border-radius: 12px;
   border: none;
-  background: rgba(255, 255, 255, 0.15);
+  background: transparent;
   color: #fff;
   font-size: 1rem;
+}
+
+.hero-search select {
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.hero-search option {
+  color: #2a1122;
 }
 
 .hero-search input::placeholder {
@@ -362,9 +449,9 @@ img {
 }
 
 .hero-search button[type="submit"] {
-  background: var(--accent);
-  color: #221a13;
-  box-shadow: 0 12px 20px rgba(199, 119, 60, 0.32);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #3b1405;
+  box-shadow: 0 12px 22px rgba(243, 114, 44, 0.4);
 }
 
 .hero-search button[type="submit"]:hover,
@@ -389,10 +476,25 @@ img {
   background: rgba(255, 255, 255, 0.12);
 }
 
+.tools {
+  margin-top: clamp(2.4rem, 5vw, 3rem);
+}
+
+.section-heading {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-family: 'Spectral', 'Times New Roman', serif;
+  font-size: clamp(1.8rem, 3.5vw, 2.4rem);
+}
+
 .card-grid {
   display: grid;
   gap: clamp(1.2rem, 3vw, 1.8rem);
-  margin-top: clamp(2.4rem, 5vw, 3rem);
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
 }
 
@@ -401,9 +503,9 @@ img {
   overflow: hidden;
   border-radius: 20px;
   padding: 1.75rem 1.6rem;
-  background: linear-gradient(140deg, rgba(255, 253, 248, 0.92), rgba(248, 242, 233, 0.75));
-  border: 1px solid rgba(31, 61, 59, 0.12);
-  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  background: linear-gradient(140deg, rgba(64, 20, 40, 0.96), rgba(42, 14, 30, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.4);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
   color: var(--text-color);
 }
@@ -414,18 +516,18 @@ img {
   inset: -40% -20% auto auto;
   width: 160px;
   height: 160px;
-  background: radial-gradient(circle at center, rgba(199, 119, 60, 0.25), transparent 65%);
+  background: radial-gradient(circle at center, rgba(243, 114, 44, 0.35), transparent 65%);
   transform: rotate(25deg);
 }
 
 .card:hover,
 .card:focus {
   transform: translateY(-6px);
-  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 26px 50px rgba(0, 0, 0, 0.45);
 }
 
 .card-icon {
-  font-size: 2rem;
+  font-size: 2.1rem;
   margin-bottom: 0.8rem;
 }
 
@@ -436,28 +538,43 @@ img {
   letter-spacing: 0.01em;
 }
 
-.card-about {
-  grid-column: span 2;
-  display: flex;
-  align-items: center;
-  gap: 1.1rem;
-  background: linear-gradient(135deg, rgba(199, 119, 60, 0.9), rgba(234, 198, 167, 0.85));
-  color: #2f1c01;
+.card p {
+  margin: 0.75rem 0 1.4rem;
+  color: rgba(248, 238, 232, 0.8);
 }
 
-.card-about::after {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.4), transparent 70%);
+.card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(243, 114, 44, 0.9), rgba(255, 158, 67, 0.85));
+  color: #3b1405;
+  font-weight: 600;
 }
 
 .culture-band {
   margin-top: clamp(2.5rem, 5vw, 3.5rem);
-  background: linear-gradient(140deg, rgba(31, 61, 59, 0.08), rgba(199, 119, 60, 0.15));
-  border: 1px solid rgba(31, 61, 59, 0.12);
+  background: linear-gradient(160deg, rgba(36, 10, 22, 0.98), rgba(58, 18, 36, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 28px;
   padding: clamp(2rem, 4vw, 2.8rem);
-  box-shadow: 0 22px 38px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 22px 38px rgba(0, 0, 0, 0.4);
   position: relative;
   overflow: hidden;
+}
+
+.culture-band::before {
+  content: '';
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 45%;
+  background:
+    linear-gradient(180deg, transparent, rgba(21, 6, 14, 0.95)),
+    radial-gradient(circle at 20% 60%, rgba(243, 114, 44, 0.25), transparent 55%);
+  opacity: 0.9;
+  pointer-events: none;
 }
 
 .culture-band::after {
@@ -465,7 +582,7 @@ img {
   position: absolute;
   inset: 0;
   background: var(--pattern);
-  opacity: 0.35;
+  opacity: 0.18;
   pointer-events: none;
 }
 
@@ -506,13 +623,58 @@ img {
   align-items: flex-start;
   padding: 0.9rem 1rem;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(31, 61, 59, 0.08);
+  background: rgba(19, 7, 14, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .culture-points strong {
   font-weight: 700;
-  color: var(--primary);
+  color: var(--accent-soft);
+}
+
+.action-row {
+  margin-top: clamp(2.5rem, 5vw, 3.5rem);
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.action-card {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.2rem 1.4rem;
+  border-radius: 20px;
+  background: rgba(19, 7, 14, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+}
+
+.action-card p {
+  margin: 0;
+  color: rgba(248, 238, 232, 0.75);
+}
+
+.action-card:hover,
+.action-card:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 35px rgba(0, 0, 0, 0.45);
+}
+
+.action-icon {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: rgba(243, 114, 44, 0.2);
+  font-size: 1.4rem;
 }
 
 .visitor-stats {
@@ -536,11 +698,11 @@ img {
 }
 
 .page-shell {
-  background: var(--surface);
+  background: rgba(25, 9, 18, 0.92);
   border-radius: 32px;
   padding: clamp(1.75rem, 4vw, 2.75rem);
   box-shadow: var(--shadow);
-  border: 1px solid rgba(31, 61, 59, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   display: grid;
   gap: 1.75rem;
 }
@@ -551,7 +713,7 @@ img {
   align-items: center;
   gap: clamp(1.5rem, 4vw, 3rem);
   padding-bottom: 1.5rem;
-  border-bottom: 1px solid rgba(31, 61, 59, 0.12);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .page-emblem {
@@ -560,10 +722,10 @@ img {
   border-radius: 22px;
   display: grid;
   place-items: center;
-  background: rgba(199, 119, 60, 0.16);
-  color: #7a3f18;
+  background: rgba(240, 124, 43, 0.2);
+  color: #f8c48b;
   font-size: clamp(1.7rem, 3vw, 2.3rem);
-  box-shadow: inset 0 0 0 1px rgba(199, 119, 60, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(240, 124, 43, 0.35);
 }
 
 .section-kicker {
@@ -574,14 +736,14 @@ img {
   letter-spacing: 0.32em;
   font-size: 0.7rem;
   font-weight: 700;
-  color: rgba(31, 61, 59, 0.6);
+  color: rgba(248, 196, 139, 0.7);
 }
 
 .page-empty {
   margin: 0;
   padding: 0.75rem 1rem;
   border-radius: 16px;
-  background: rgba(31, 61, 59, 0.06);
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-muted);
 }
 
@@ -602,15 +764,16 @@ img {
   min-width: 0;
   padding: 0.85rem 1.1rem;
   border-radius: 16px;
-  border: 1px solid rgba(31, 61, 59, 0.18);
-  background: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
   font-size: 1rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  color: var(--text-color);
 }
 
 .search-input:focus {
-  border-color: rgba(31, 61, 59, 0.4);
-  box-shadow: 0 0 0 4px rgba(199, 119, 60, 0.18);
+  border-color: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 0 4px rgba(240, 124, 43, 0.2);
   outline: none;
 }
 
@@ -618,8 +781,8 @@ img {
   padding: 0.85rem 1.4rem;
   border-radius: 16px;
   border: none;
-  background: var(--primary);
-  color: #f8fafc;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #3b1405;
   font-weight: 700;
   letter-spacing: 0.02em;
   cursor: pointer;
@@ -628,20 +791,20 @@ img {
 
 .search-btn:hover,
 .search-btn:focus {
-  background: #2a5854;
-  box-shadow: 0 12px 22px rgba(31, 61, 59, 0.18);
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 12px 22px rgba(240, 124, 43, 0.35);
   transform: translateY(-2px);
 }
 
 .direction-btn {
-  background: rgba(31, 61, 59, 0.08);
-  color: var(--primary);
-  border: 1px solid rgba(31, 61, 59, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--accent-soft);
+  border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .direction-btn:hover,
 .direction-btn:focus {
-  background: rgba(31, 61, 59, 0.12);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .results-list {
@@ -650,19 +813,19 @@ img {
   padding: 0;
   border-radius: 20px;
   overflow: hidden;
-  border: 1px solid rgba(31, 61, 59, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .results-list li {
   padding: 0.95rem 1.2rem;
-  background: rgba(255, 255, 255, 0.85);
-  border-bottom: 1px solid rgba(31, 61, 59, 0.08);
+  background: rgba(24, 8, 18, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   cursor: pointer;
   transition: background 0.2s ease, padding-left 0.2s ease;
 }
 
 .results-list li:hover {
-  background: rgba(199, 119, 60, 0.16);
+  background: rgba(240, 124, 43, 0.18);
   padding-left: 1.35rem;
 }
 
@@ -674,9 +837,9 @@ img {
   margin-top: 2rem;
   padding: 1.6rem;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(31, 61, 59, 0.08);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  background: rgba(24, 8, 18, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
 }
 
 .phrasebook-list {
@@ -687,11 +850,11 @@ img {
 .phrasebook-section,
 .names-section,
 .contact-card {
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(24, 8, 18, 0.92);
   border-radius: 24px;
   padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid rgba(31, 61, 59, 0.1);
-  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.35);
 }
 
 .phrasebook-section__title,
@@ -712,15 +875,15 @@ img {
 .names-table th,
 .names-table td {
   padding: 0.85rem 1rem;
-  border-bottom: 1px solid rgba(31, 61, 59, 0.12);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   text-align: left;
   vertical-align: top;
 }
 
 .phrasebook-table thead,
 .names-table thead {
-  background: rgba(31, 61, 59, 0.08);
-  color: var(--primary-dark);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--accent-soft);
 }
 
 .phrasebook-table th,
@@ -747,27 +910,27 @@ img {
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 700;
-  background: rgba(31, 61, 59, 0.08);
-  color: var(--primary);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--accent-soft);
 }
 
 .names-badge--male {
-  background: rgba(14, 165, 233, 0.18);
-  color: #0c4a6e;
+  background: rgba(56, 189, 248, 0.2);
+  color: #bae6fd;
 }
 
 .names-badge--female {
-  background: rgba(236, 72, 153, 0.2);
-  color: #9d174d;
+  background: rgba(244, 114, 182, 0.2);
+  color: #fbcfe8;
 }
 
 .names-badge--unisex {
-  background: rgba(34, 197, 94, 0.18);
-  color: #0f766e;
+  background: rgba(74, 222, 128, 0.2);
+  color: #bbf7d0;
 }
 
 .site-footer {
-  background: #0b1c1b;
+  background: #13050f;
   color: rgba(255, 255, 255, 0.82);
   padding: clamp(2rem, 5vw, 3rem) 0;
   position: relative;
@@ -780,7 +943,7 @@ img {
   inset: auto auto -140px -120px;
   width: 320px;
   height: 320px;
-  background: radial-gradient(circle at center, rgba(199, 119, 60, 0.45), transparent 70%);
+  background: radial-gradient(circle at center, rgba(240, 124, 43, 0.45), transparent 70%);
   opacity: 0.7;
 }
 
@@ -810,7 +973,7 @@ img {
   gap: 0.75rem;
   margin-top: 1.2rem;
   padding-top: 1.2rem;
-  border-top: 1px solid rgba(31, 61, 59, 0.12);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .contact-details div {
@@ -822,7 +985,7 @@ img {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.25em;
-  color: rgba(31, 61, 59, 0.6);
+  color: rgba(248, 196, 139, 0.7);
   font-weight: 700;
 }
 
@@ -897,9 +1060,30 @@ img {
   }
 
   .site-nav .nav-cta {
-    border: 1px solid rgba(199, 119, 60, 0.6);
-    background: rgba(199, 119, 60, 0.22);
+    border: 1px solid rgba(240, 124, 43, 0.6);
+    background: rgba(240, 124, 43, 0.22);
     text-align: center;
+  }
+
+  .hero-inner {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-media img {
+    width: min(300px, 70%);
+  }
+
+  .hero-content {
+    justify-items: center;
+  }
+
+  .hero-search {
+    justify-content: center;
+  }
+
+  .search-field {
+    width: min(100%, 420px);
   }
 }
 
@@ -930,9 +1114,6 @@ img {
     align-items: flex-start;
   }
 
-  .card-about {
-    grid-column: span 1;
-  }
 }
 
 @media (max-width: 640px) {
@@ -972,7 +1153,7 @@ img {
   .names-table tr {
     display: block;
     padding: 0.85rem 0;
-    border-bottom: 1px solid rgba(31, 61, 59, 0.12);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   }
 
   .phrasebook-table td,

--- a/website/static/website/images/hero-illustration.svg
+++ b/website/static/website/images/hero-illustration.svg
@@ -1,0 +1,31 @@
+<svg width="480" height="360" viewBox="0 0 480 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="heroBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4b1430"/>
+      <stop offset="1" stop-color="#2a0d1f"/>
+    </linearGradient>
+    <linearGradient id="heroAccent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f07c2b"/>
+      <stop offset="1" stop-color="#ff9b3f"/>
+    </linearGradient>
+  </defs>
+  <rect x="20" y="20" width="440" height="320" rx="40" fill="url(#heroBg)" stroke="#f07c2b" stroke-opacity="0.2" stroke-width="2"/>
+  <circle cx="150" cy="150" r="70" fill="#f6e1d2"/>
+  <path d="M96 138c14-20 40-30 70-14" stroke="#2b0f1a" stroke-width="8" stroke-linecap="round"/>
+  <path d="M114 186c16 16 52 16 68 0" stroke="#2b0f1a" stroke-width="8" stroke-linecap="round"/>
+  <rect x="84" y="86" width="132" height="30" rx="15" fill="#7b7f8a"/>
+  <rect x="92" y="94" width="116" height="14" rx="7" fill="#b0b5c0"/>
+  <rect x="70" y="230" width="180" height="48" rx="24" fill="url(#heroAccent)"/>
+  <path d="M100 254c20-20 70-20 90 0" stroke="#f6e1d2" stroke-width="8" stroke-linecap="round"/>
+  <g>
+    <path d="M260 120c0-22 18-40 40-40h46c22 0 40 18 40 40v16c0 22-18 40-40 40h-12l-22 16v-16h-12c-22 0-40-18-40-40v-16z" fill="#4e9dd4" stroke="#f6e1d2" stroke-width="4"/>
+    <text x="304" y="146" fill="#1a0a12" font-family="Manrope, sans-serif" font-size="28" font-weight="700">A</text>
+  </g>
+  <g>
+    <path d="M300 190c0-20 16-36 36-36h46c20 0 36 16 36 36v12c0 20-16 36-36 36h-12l-18 14v-14h-16c-20 0-36-16-36-36v-12z" fill="#f6f0ee" stroke="#6b1b29" stroke-width="4"/>
+    <text x="330" y="214" fill="#6b1b29" font-family="Manrope, sans-serif" font-size="22" font-weight="700">AVAR</text>
+  </g>
+  <circle cx="356" cy="86" r="10" fill="#ff9b3f" opacity="0.6"/>
+  <circle cx="380" cy="300" r="8" fill="#f07c2b" opacity="0.5"/>
+  <circle cx="80" cy="300" r="6" fill="#ff9b3f" opacity="0.5"/>
+</svg>

--- a/website/static/website/images/logo-mark.svg
+++ b/website/static/website/images/logo-mark.svg
@@ -1,0 +1,22 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4b1430"/>
+      <stop offset="1" stop-color="#2a0d1f"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f07c2b"/>
+      <stop offset="1" stop-color="#ff9b3f"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="104" height="104" rx="28" fill="url(#bg)" stroke="#f07c2b" stroke-opacity="0.35" stroke-width="2"/>
+  <circle cx="60" cy="50" r="22" fill="#f6e1d2"/>
+  <path d="M38 46c6-9 18-14 34-6" stroke="#2b0f1a" stroke-width="4" stroke-linecap="round"/>
+  <path d="M46 62c6 6 22 6 28 0" stroke="#2b0f1a" stroke-width="4" stroke-linecap="round"/>
+  <rect x="28" y="24" width="64" height="16" rx="8" fill="#7b7f8a"/>
+  <rect x="32" y="28" width="56" height="10" rx="5" fill="#b0b5c0"/>
+  <path d="M24 84h72" stroke="url(#accent)" stroke-width="8" stroke-linecap="round"/>
+  <path d="M30 84c10-10 26-10 36 0" stroke="#f6e1d2" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="84" cy="72" r="10" fill="#4e9dd4" stroke="#f6e1d2" stroke-width="2"/>
+  <text x="80" y="76" fill="#1a0a12" font-family="Manrope, sans-serif" font-size="10" font-weight="700">A</text>
+</svg>

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -7,7 +7,7 @@
   <title>{% block title %}Avaro-English{% endblock %}</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&family=Spectral:wght@500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&family=Spectral:wght@500;600;700&family=Rubik:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{% static 'website/css/styles.css' %}">
 </head>
 <body>
@@ -17,8 +17,11 @@
       <div class="header-pattern" aria-hidden="true"></div>
       <div class="container header-bar">
         <a href="{% url 'home' %}" class="logo">
-          <span class="logo-kicker">Avar Language ↔ English</span>
-          <span class="logo-title">Avaro-English</span>
+          <img src="{% static 'website/images/logo-mark.svg' %}" alt="" class="logo-mark">
+          <span class="logo-text">
+            <span class="logo-kicker">Avar Language Portal</span>
+            <span class="logo-title">SaidoBavar</span>
+          </span>
         </a>
         <button class="btn-menu" aria-label="Toggle menu">☰</button>
         <nav class="site-nav" aria-label="Primary navigation">
@@ -26,8 +29,7 @@
           <a href="{% url 'phrasebook' %}">Phrasebook</a>
           <a href="{% url 'grammar' %}">Grammar</a>
           <a href="{% url 'names' %}">Names</a>
-          <a href="{% url 'about' %}">About</a>
-          <a href="{% url 'contact' %}" class="nav-cta">Contact</a>
+          <a href="{% url 'contact' %}" class="nav-cta">Contribute word</a>
         </nav>
         <div class="lang-switcher">
           <button class="btn-lang" type="button" aria-haspopup="true" aria-expanded="false">
@@ -52,7 +54,7 @@
     <footer class="site-footer">
       <div class="container footer-inner">
         <div>
-          <span class="footer-brand">Avaro-English</span>
+          <span class="footer-brand">SaidoBavar</span>
           <p class="footer-text">A digital home for learning and celebrating the Avar language.</p>
         </div>
         <div class="footer-meta">
@@ -63,7 +65,7 @@
           <a href="{% url 'about' %}">About</a>
           <a href="{% url 'contact' %}">Contact</a>
         </div>
-        <p class="footer-copy">© {% now "Y" %} Avaro-English</p>
+        <p class="footer-copy">© {% now "Y" %} SaidoBavar</p>
       </div>
     </footer>
   </div>

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -1,60 +1,105 @@
 {% extends "website/base.html" %}
-{% block title %}Home – Avaro-English{% endblock %}
+{% block title %}Home – SaidoBavar{% endblock %}
 
 {% block content %}
 <section class="hero">
   <div class="hero-inner">
-    <span class="hero-kicker">Avar Language • Heritage</span>
-    <h1 class="hero-title">A modern portal for exploring the Avar language</h1>
-    <p class="hero-lede">We blend the spirit of the Caucasus highlands with digital craft so the living voice of Avar speech stays vibrant, discoverable, and ready to share.</p>
+    <div class="hero-media" aria-hidden="true">
+      <img src="{% static 'website/images/hero-illustration.svg' %}" alt="">
+    </div>
+    <div class="hero-content">
+      <span class="hero-kicker">Avar Language Portal</span>
+      <h1 class="hero-title">Avar Language · <span>Сайт об Аварском</span></h1>
+      <p class="hero-lede">Современный портал об аварском языке: живой словарь, фразы и грамматика в удобном цифровом формате.</p>
 
-    <div class="hero-actions">
       <form method="get" action="{% url 'dictionary' %}" class="hero-search">
-        <input type="search" name="q" placeholder="Search for a word or root…" required>
-        <button type="submit">Search the dictionary</button>
+        <label class="sr-only" for="hero-search">Search</label>
+        <div class="search-field">
+          <span class="search-icon">🔎</span>
+          <input id="hero-search" type="search" name="q" placeholder="Search Avar" required>
+          <select name="direction" aria-label="Translation direction">
+            <option value="av-en">Avar</option>
+            <option value="en-av">English</option>
+          </select>
+        </div>
+        <button type="submit">Search</button>
       </form>
       <div class="hero-footnote">
-        <span>🧭 Active visitors now: {{ active_visitors }}</span>
-        <span>🌞 Unique visitors today: {{ unique_visitors_today }}</span>
-        <span>⛰️ Avar heritage in a digital format</span>
+        <span>Active visitors now: {{ active_visitors }}</span>
+        <span>Words in dictionary: 12,345</span>
+        <span>Since 2024</span>
       </div>
     </div>
   </div>
 </section>
 
-<div class="card-grid">
-  <a href="{% url 'dictionary' %}" class="card">
-    <div class="card-icon">📖</div>
-    <div class="card-label">Dictionary</div>
-  </a>
-  <a href="{% url 'phrasebook' %}" class="card">
-    <div class="card-icon">💬</div>
-    <div class="card-label">Phrasebook</div>
-  </a>
-  <a href="{% url 'grammar' %}" class="card">
-    <div class="card-icon">📚</div>
-    <div class="card-label">Grammar</div>
-  </a>
-  <a href="{% url 'names' %}" class="card">
-    <div class="card-icon">👥</div>
-    <div class="card-label">Names</div>
-  </a>
-  <a href="{% url 'about' %}" class="card card-about">
-    <div class="card-icon">ℹ️</div>
-    <div class="card-label">About the project</div>
-  </a>
-</div>
+<section class="tools">
+  <div class="section-heading">
+    <span class="section-kicker">Tools for Avar learners</span>
+    <h2>Tools for Avar learners</h2>
+  </div>
+  <div class="card-grid">
+    <a href="{% url 'dictionary' %}" class="card">
+      <div class="card-icon">📖</div>
+      <div class="card-label">Dictionary</div>
+      <p>Fast search with rich entries, roots, and examples.</p>
+      <span class="card-cta">Open dictionary</span>
+    </a>
+    <a href="{% url 'phrasebook' %}" class="card">
+      <div class="card-icon">💬</div>
+      <div class="card-label">Phrasebook</div>
+      <p>Everyday expressions and curated conversational phrases.</p>
+      <span class="card-cta">Open phrasebook</span>
+    </a>
+    <a href="{% url 'grammar' %}" class="card">
+      <div class="card-icon">📚</div>
+      <div class="card-label">Grammar</div>
+      <p>Clear patterns, declensions, and grammar insights.</p>
+      <span class="card-cta">Open grammar</span>
+    </a>
+    <a href="{% url 'names' %}" class="card">
+      <div class="card-icon">🔤</div>
+      <div class="card-label">Names</div>
+      <p>Beautiful Avar names with meaning and origin.</p>
+      <span class="card-cta">Open names</span>
+    </a>
+  </div>
+</section>
 
 <section class="culture-band">
   <div class="culture-band__header">
-    <span class="section-kicker">Culture &amp; craft</span>
+    <span class="section-kicker">The voice of Avar culture</span>
     <h2>The voice of Avar culture</h2>
   </div>
-  <p>Inspired by mountain landscapes, artisan patterns, and stories shared across generations, we are shaping a digital space where the Avar language feels warm, current, and welcoming.</p>
+  <p>Практические инструменты, сообщество и сохранение наследия — всё в одном месте для языка и культуры Аварцев.</p>
   <ul class="culture-points">
-    <li><strong>Practical tools.</strong> Explore dictionary entries, phrasebook examples, and grammar notes that connect Avar and English with ease.</li>
-    <li><strong>Community roots.</strong> Contribute words, share insights, and encourage fellow learners on every step of their journey.</li>
-    <li><strong>Preserving heritage.</strong> Every search and shared phrase strengthens the future of the Avar language.</li>
+    <li><strong>Практические инструменты.</strong> Словарь, фразы и грамматика в одном месте.</li>
+    <li><strong>Корни сообщества.</strong> Каждый может добавить слово или пример.</li>
+    <li><strong>Сохранение наследия.</strong> Каждый поиск укрепляет будущее языка.</li>
   </ul>
+</section>
+
+<section class="action-row">
+  <a class="action-card" href="{% url 'contact' %}">
+    <div class="action-icon">🛠️</div>
+    <div>
+      <h3>Report an error</h3>
+      <p>Help us keep the dictionary accurate.</p>
+    </div>
+  </a>
+  <a class="action-card" href="{% url 'contact' %}">
+    <div class="action-icon">➕</div>
+    <div>
+      <h3>Suggest a word</h3>
+      <p>Share a new entry or phrase for review.</p>
+    </div>
+  </a>
+  <a class="action-card" href="{% url 'about' %}">
+    <div class="action-icon">✨</div>
+    <div>
+      <h3>Share project</h3>
+      <p>Spread the word about the Avar language.</p>
+    </div>
+  </a>
 </section>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Replace the previous homepage UI with the supplied Avar-inspired example and bilingual copy to match the requested design direction.  
- Introduce a deep maroon/orange visual system and updated typography to strengthen the site identity.  
- Surface a compact logo mark and a hero illustration to support the new layout and branding.  

### Description
- Restyled the global theme and components in `website/static/website/css/styles.css`, updating CSS variables, hero/search layout, cards, section treatments, and responsive rules.  
- Reworked the homepage in `website/templates/website/index.html` to add the new hero layout (media + content), bilingual headings/text, an inline search field, tools/cards, culture section, and an action row.  
- Updated `website/templates/website/base.html` to add the `Rubik` font, swap the text-only logo for the new mark + text block, adjust the nav CTA to `Contribute word`, and update footer branding to `SaidoBavar`.  
- Added SVG assets `website/static/website/images/logo-mark.svg` and `website/static/website/images/hero-illustration.svg` and wired them into the templates.  

### Testing
- Launched the dev server with `python manage.py runserver 0.0.0.0:8000`, which started successfully but reported `21 unapplied migration(s)` as a warning.  
- Ran a Playwright visual smoke script that produced a homepage screenshot at `artifacts/home.png` (succeeded).  
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9e4de540832da3ce8985154784b9)